### PR TITLE
Add splitter support in VanillaStyle

### DIFF
--- a/example/MainWindow.cpp
+++ b/example/MainWindow.cpp
@@ -34,7 +34,6 @@ MainWindow::MainWindow(QWidget* parent)
     ui->toggleBtnfirst->setToolTips(QStringList{"Default", "Account", "Advance"});
     ui->toggleBtnfirst->setColumnWidth(50);
 
-    // ui->toggleBtnSecond->setUseIcon(false);
     ui->toggleBtnSecond->setItemList(QStringList{"Default", "Account", "Advance"});
     ui->toggleBtnSecond->setColumnWidth(100);
 
@@ -43,13 +42,10 @@ MainWindow::MainWindow(QWidget* parent)
     ui->iconWithText->setColumnWidth(120);
     ui->iconWithText->setVertical();
     ui->iconWithText->setRowHeight(40);
-    // ui->iconWithText->setHandlePadding(4);
 
     ui->radioButton->setChecked(true);
 
     ui->pushButton->setCheckable(true);
-    // auto spinner = new Vanilla::Spinner(this);
-    // ui->verticalLayout->addWidget(spinner);
 
     connect(ui->radioButton, &QRadioButton::toggled, this, &MainWindow::setLightTheme);
     connect(ui->radioButton_2, &QRadioButton::toggled, this, &MainWindow::setDarkTheme);
@@ -66,15 +62,10 @@ MainWindow::MainWindow(QWidget* parent)
 
     ui->startButton->setProperty(VANILLA_PATCH_PROPERTY, QVariant("CleanButtonPatch"));
     ui->startButton->setText("");
-    // ui->startButton->setIcon(QIcon(":/download.svg"));
     connect(ui->startButton, &QPushButton::clicked, this, &MainWindow::start);
     connect(ui->stopButton, &QPushButton::clicked, this, &MainWindow::stop);
     connect(m_timer, &QTimer::timeout, this, &MainWindow::increaseProgress);
 
-    const auto testAction = ui->lineEdit->addAction(QIcon(":lineEditAction.svg"), QLineEdit::TrailingPosition);
-
-    ui->lineEdit->addAction(QIcon(":download.svg"), QLineEdit::TrailingPosition);
-    ui->lineEdit->addAction(QIcon(":download.svg"), QLineEdit::LeadingPosition);
     connect(ui->pushButton, &QPushButton::clicked, this, &MainWindow::setAutoTheme);
 
     ui->listWidget->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
@@ -95,8 +86,6 @@ MainWindow::MainWindow(QWidget* parent)
         checkBoxItem->setCheckState(Qt::Checked);  // 初始状态为未选中
         ui->tableWidget->setItem(row, 1, checkBoxItem);
     }
-
-    // ui->tableWidget->setShowGrid(false);
 }
 
 MainWindow::~MainWindow()

--- a/example/MainWindow.ui
+++ b/example/MainWindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>744</width>
-    <height>787</height>
+       <height>841</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -192,29 +192,78 @@
      </widget>
     </item>
     <item>
-     <widget class="Vanilla::ToggleButton" name="iconWithText" native="true">
-      <property name="_vanillaStyle_Patch" stdset="0">
-       <string notr="true">CustomToggleButtonPatch</string>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QWidget" name="widget_5" native="true">
-      <layout class="QHBoxLayout" name="horizontalLayout_5">
-       <item>
-        <widget class="QLabel" name="label_4">
-         <property name="text">
-          <string>LineEdit:</string>
-         </property>
+        <widget class="QWidget" name="widget_4" native="true">
+            <layout class="QHBoxLayout" name="horizontalLayout_4">
+                <property name="leftMargin">
+                    <number>0</number>
+                </property>
+                <property name="topMargin">
+                    <number>0</number>
+                </property>
+                <property name="rightMargin">
+                    <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                    <number>0</number>
+                </property>
+                <item>
+                    <widget class="Vanilla::ToggleButton" name="iconWithText" native="true">
+                        <property name="_vanillaStyle_Patch" stdset="0">
+                            <string notr="true">CustomToggleButtonPatch</string>
+                        </property>
+                    </widget>
+                </item>
+                <item>
+                    <widget class="QWidget" name="widget_9" native="true">
+                        <property name="minimumSize">
+                            <size>
+                                <width>0</width>
+                                <height>50</height>
+                            </size>
+                        </property>
+                        <layout class="QVBoxLayout" name="verticalLayout_2">
+                            <property name="leftMargin">
+                                <number>0</number>
+                            </property>
+                            <property name="topMargin">
+                                <number>0</number>
+                            </property>
+                            <property name="rightMargin">
+                                <number>0</number>
+                            </property>
+                            <property name="bottomMargin">
+                                <number>0</number>
+                            </property>
+                            <item>
+                                <widget class="QSplitter" name="splitter">
+                                    <property name="orientation">
+                                        <enum>Qt::Vertical</enum>
+                                    </property>
+                                    <widget class="QLabel" name="label_10">
+                                        <property name="text">
+                                            <string>TextLabel</string>
+                                        </property>
+                                    </widget>
+                                    <widget class="QLabel" name="label_11">
+                                        <property name="text">
+                                            <string>TextLabel</string>
+                                        </property>
+                                    </widget>
+                                </widget>
+                            </item>
+                        </layout>
+                    </widget>
+                </item>
+            </layout>
         </widget>
-       </item>
+    </item>
        <item>
-        <widget class="QLineEdit" name="lineEdit">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
+           <widget class="QWidget" name="widget_5" native="true">
+               <layout class="QHBoxLayout" name="horizontalLayout_5">
+                   <item>
+                       <widget class="QLabel" name="label_4">
+                           <property name="text">
+                               <string>LineEdit:</string>
          </property>
         </widget>
        </item>
@@ -249,15 +298,22 @@
         </widget>
        </item>
       </layout>
+           </widget>
+       </item>
+       <item>
+           <widget class="QLabel" name="label_7">
+               <property name="text">
+                   <string>TextLabel</string>
+               </property>
      </widget>
     </item>
     <item>
      <widget class="QListWidget" name="listWidget">
       <property name="verticalScrollBarPolicy">
-       <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOn</enum>
+          <enum>Qt::ScrollBarAlwaysOn</enum>
       </property>
       <property name="horizontalScrollBarPolicy">
-       <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOn</enum>
+          <enum>Qt::ScrollBarAlwaysOn</enum>
       </property>
       <item>
        <property name="text">

--- a/vanillastyle/include/VanillaStyle/Helper/Helper.h
+++ b/vanillastyle/include/VanillaStyle/Helper/Helper.h
@@ -20,6 +20,10 @@ public:
     bool drawAlignCenterLabel(const QStyleOption*, QPainter*, const std::shared_ptr<Theme>&, const QWidget*) const;
     bool drawAlignLeftLabel(const QStyleOption*, QPainter*, const std::shared_ptr<Theme>&, const QWidget*) const;
 
+    bool drawSplitter(const QStyleOption*, QPainter*, const std::shared_ptr<Theme>&, const QWidget*) const;
+    QSize sizeFromContentsForSplitterHandle(QStyle::ContentsType type, const QStyleOption* option, const QSize& contentsSize,
+                                            const std::shared_ptr<Theme>& theme, const QWidget* widget);
+
     static void renderRoundBorder(QPainter* painter, const QRectF& rect, const QColor& color, qreal border, qreal radius);
     static void renderRoundRect(QPainter* painter, const QRectF& rect, const QColor& color, qreal radius);
     static void renderEllipse(QPainter* painter, const QRectF& rect, const QColor& color);

--- a/vanillastyle/src/Helper/Helper.cpp
+++ b/vanillastyle/src/Helper/Helper.cpp
@@ -61,6 +61,25 @@ bool Helper::drawLabel(const QStyleOption* option, QPainter* painter, const std:
     return true;
 }
 
+bool Helper::drawSplitter(const QStyleOption* option, QPainter* painter, const std::shared_ptr<Theme>& theme, const QWidget* widget) const
+{
+    const auto& rect = option->rect;
+    const auto height = theme->getSize(SizeRole::ScrollBarWidth);
+    const auto width = theme->getSize(SizeRole::IconSize);
+    const auto radius = theme->getSize(SizeRole::SmallRadius);
+    const auto center = centerRectF(QRectF(rect), width, height);
+    painter->setRenderHints(QPainter::Antialiasing);
+    renderRoundRect(painter, center, Qt::gray, radius);
+    return true;
+}
+
+QSize Helper::sizeFromContentsForSplitterHandle(QStyle::ContentsType type, const QStyleOption* option, const QSize& contentsSize,
+                                                const std::shared_ptr<Theme>& theme, const QWidget* widget)
+{
+    const auto height = theme->getSize(SizeRole::ScrollBarWidth);
+    return {contentsSize.width(), height};
+}
+
 bool Helper::drawAlignCenterLabel(const QStyleOption* option, QPainter* painter, const std::shared_ptr<Theme>& theme, const QWidget* widget) const
 {
     return drawLabel(option, painter, theme, widget, Qt::AlignCenter);
@@ -128,7 +147,6 @@ void Helper::drawCheckBoxHelper(const QStyleOption* option, QPainter* painter, c
     {
         renderRoundBorder(painter, buttonRect, borderColor, border, radius);
     }
-
 
     if ((theme->flags(option) & Theme::Checked) == Theme::Checked)
     {

--- a/vanillastyle/src/Helper/Helper.cpp
+++ b/vanillastyle/src/Helper/Helper.cpp
@@ -67,9 +67,10 @@ bool Helper::drawSplitter(const QStyleOption* option, QPainter* painter, const s
     const auto height = theme->getSize(SizeRole::ScrollBarWidth);
     const auto width = theme->getSize(SizeRole::IconSize);
     const auto radius = theme->getSize(SizeRole::SmallRadius);
+    const auto color = theme->getColor(option, ColorRole::ButtonForeground);
     const auto center = centerRectF(QRectF(rect), width, height);
     painter->setRenderHints(QPainter::Antialiasing);
-    renderRoundRect(painter, center, Qt::gray, radius);
+    renderRoundRect(painter, center, color, radius);
     return true;
 }
 

--- a/vanillastyle/src/Style/VanillaStyle.cpp
+++ b/vanillastyle/src/Style/VanillaStyle.cpp
@@ -60,9 +60,6 @@ void VanillaStyle::drawPrimitive(PrimitiveElement pe, const QStyleOption* option
     case PE_PanelItemViewRow:
         helper = createHelper(d->helper, &Helper::emptyControl);
         break;
-    // case PE_IndicatorItemViewItemCheck:
-    //     helper = createHelper(d->itemViewStyle, &ItemViewStyle::drawCheck);
-    //     break;
     case PE_IndicatorRadioButton:
         helper = createHelper(d->radioButtonStyle, &RadioButtonStyle::draw);
         break;
@@ -133,6 +130,9 @@ void VanillaStyle::drawControl(ControlElement element, const QStyleOption* optio
         break;
     case CE_ToolButtonLabel:
         helper = createHelper(d->toolButtonStyle, &ToolButtonStyle::drawToolButtonLabel);
+        break;
+    case CE_Splitter:
+        helper = createHelper(d->helper, &Helper::drawSplitter);
         break;
     case CE_ScrollBarAddPage:
     case CE_ScrollBarSubPage:
@@ -226,6 +226,8 @@ QSize VanillaStyle::sizeFromContents(ContentsType type, const QStyleOption* opti
     case CT_ItemViewItem:
         helper = createHelper(d->itemViewStyle, &ItemViewStyle::sizeFromContentsForItemView);
         break;
+    case CT_Splitter:
+        helper = createHelper(d->helper, &Helper::sizeFromContentsForSplitterHandle);
     default:
         break;
     }

--- a/vanillastyle/src/Widgets/ToggleButton.cpp
+++ b/vanillastyle/src/Widgets/ToggleButton.cpp
@@ -146,7 +146,6 @@ void ToggleButton::setRowHeight(const int height)
     Q_D(ToggleButton);
     d->rowHeight = height;
     d->handleSize = d->getHandleSize();
-    // d->iconSize = d->getIconSize();
     update();
 }
 
@@ -159,7 +158,11 @@ int ToggleButton::currentIndex() const
 void ToggleButton::setCurrentIndex(int index)
 {
     Q_D(ToggleButton);
-    d->setCurrentIndex(index);
+    if (index != d->currentIndex)
+    {
+        d->setCurrentIndex(index);
+        emit currentItemChanged(index);
+    }
     update();
 }
 
@@ -207,12 +210,12 @@ bool ToggleButton::event(QEvent* event)
     {
     case QEvent::ToolTip:
     {
-        auto helpEvent = static_cast<QHelpEvent*>(event);
+        const auto helpEvent = dynamic_cast<QHelpEvent*>(event);
         const auto index = d->isVertical ? helpEvent->y() / d->rowHeight : helpEvent->x() / d->columnWidth;
 
         if (!d->toolTipsList.isEmpty() && (index >= 0 && index < d->toolTipsList.size()))
         {
-            QToolTip::showText(static_cast<QHelpEvent*>(event)->globalPos(), d->toolTipsList.at(index), this, QRect(), toolTipDuration());
+            QToolTip::showText(dynamic_cast<QHelpEvent*>(event)->globalPos(), d->toolTipsList.at(index), this, QRect(), toolTipDuration());
         }
         else
         {


### PR DESCRIPTION
Implemented drawing and sizing for splitters in the VanillaStyle. Updated the UI to include a QSplitter widget and adjusted related settings for consistent style management. Removed commented-out and unused code for better readability and maintenance.