### PR TITLE
Chore/ci (#17)

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -12,28 +12,25 @@ on:
 jobs:
   build-linux:
     name: Build On Ubuntu
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 120
 
     strategy:
       matrix:
         build_type: [Release]
+        install_path: [ installed ]
         c_compiler: [gcc]
         cpp_compiler: [g++]
-
-
+        qt: [ 6.5.2 ]
+        qt_modules: [ qtwebengine qtwebchannel qtpositioning qtpdf qtimageformats qt5compat qtserialport ]
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE.
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          submodules: true
 
-      - name: Init Submodules
-        run: |
-          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
-          git submodule sync --recursive
-          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive
+      - uses: lukka/get-cmake@latest
 
       - name: Install linuxdeploy
         uses: miurahr/install-linuxdeploy-action@v1
@@ -45,37 +42,47 @@ jobs:
           sudo DEBIAN_FRONTEND=noninteractive apt-get update
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y libfcitx5-qt-dev tree
 
-      - name: Cache Qt
-        id: cache-qt
-        uses: actions/cache@v1  # not v2!
-        with:
-          path: ../Qt
-          key: ${{ runner.os }}-QtCache-6.5
-
       - name: Install Qt
         uses: jurplel/install-qt-action@v3
         with:
-          version: 6.5.2
+          version: ${{matrix.qt}}
           target: desktop
-          modules: 'qtwebengine qtwebchannel qtpositioning qtpdf qtimageformats qt5compat'
+          modules: ${{ matrix.qt_modules }}
           cache: 'true'
 
       - name: Configure CMake
+        id: configure
         run: >
           cmake -B ${{ github.workspace }}/build
           -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
           -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-          -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install
+          -DCMAKE_INSTALL_PREFIX=${{ matrix.install_path }}
+          -DGIT_BRANCH=${{ github.ref_name }}
           -S ${{ github.workspace }}
 
-      - name:  Build Project
+      - name: Build Project
         run: cmake --build ${{ github.workspace }}/build --config ${{ matrix.build_type }} --parallel --target all --
 
-      - name:  Install Project
+      - name: Install Project
         run: cmake --build ${{ github.workspace }}/build --config ${{ matrix.build_type }} --target install --
-
+      
       # when stable to test
       # - name: Test
       #   working-directory: ${{ github.workspace }}/build
       #   run: ctest --build-config ${{ matrix.build_type }}
+
+      - name: Archive build logs on failure
+        if: ${{ failure() && (steps.configure.outcome == 'failure' || steps.runvcpkg.outcome == 'failure') }}
+        run: |
+          tar -czvf ${{ github.workspace }}/build.tar.gz -C ${{ github.workspace }}/build/ .
+          tar -czvf ${{ github.workspace }}/vcpkg.tar.gz -C ${{ github.workspace }}/ThirdParty/vcpkg/buildtrees/ .
+
+      - name: Upload build logs artifact
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux_logs
+          path: |
+            ${{ github.workspace }}/build.tar.gz
+            ${{ github.workspace }}/vcpkg.tar.gz

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -25,42 +25,26 @@ jobs:
         qt_modules: [qtwebengine]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          submodules: true
 
-      - name: Init Submodules
-        shell: bash
+      - uses: lukka/get-cmake@latest
+
+      - name: Install dependencies
         run: |
-          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
-          git submodule sync --recursive
-          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive
-
-      - name: Install Dependencies
-        run: |
-          brew install tree
-
-      - name: Install macdeployqtfix
-        run: |
-          git clone https://github.com/tamlok/macdeployqtfix.git macdeployqtfix --depth=1
-        working-directory: ${{runner.workspace}}
-
-      - name: Cache Qt
-        id: cache-qt
-        uses: actions/cache@v1  # not v2!
-        with:
-          path: ../Qt
-          key: ${{ runner.os }}-QtCache-${{ matrix.qt }}
+          xcrun --sdk macosx --show-sdk-path
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@v3
+        uses: jurplel/install-qt-action@v4
         with:
           version: ${{ matrix.qt }}
+          host: 'mac'
           target: desktop
           modules:  ${{ matrix.qt_modules }}
-          cached: 'true'
+          cache: 'true'
           setup-python: 'false'
-
+      
       - name: Configure CMake
         run: >
           cmake -B ${{ github.workspace }}/build
@@ -75,7 +59,17 @@ jobs:
       - name:  Install Project
         run: cmake --build ${{ github.workspace }}/build --config ${{ matrix.build_type }} --target install --
 
-      # when stable to test
-      # - name: Test
-      #   working-directory: ${{ github.workspace }}/build
-      #   run: ctest --build-config ${{ matrix.build_type }}
+      - name: Archive build logs on failure
+        if: ${{ failure() && (steps.configure.outcome == 'failure' || steps.runvcpkg.outcome == 'failure' || steps.build.outcome == 'failure') }}
+        run: |
+          tar -czvf ${{ github.workspace }}/build.tar.gz -C ${{ github.workspace }}/build/ .
+          tar -czvf ${{ github.workspace }}/vcpkg.tar.gz -C ${{ github.workspace }}/ThirdParty/vcpkg/buildtrees/ .
+
+      - name: Upload build logs artifact
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos_logs
+          path: |
+            ${{ github.workspace }}/build.tar.gz
+            ${{ github.workspace }}/vcpkg.tar.gz

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -27,23 +27,11 @@ jobs:
         qt_modules: [qtwebengine qtwebchannel qtpositioning qtpdf qtimageformats qt5compat]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          submodules: true
 
-      - name: Init Submodules
-        shell: bash
-        run: |
-          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
-          git submodule sync --recursive
-          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive
-
-      - name: Cache Qt
-        id: cache-qt
-        uses: actions/cache@v1  # not v2!
-        with:
-          path: ../Qt
-          key: ${{runner.os}}-${{matrix.arch}}-QtCache-${{matrix.qt}}
+      - uses: lukka/get-cmake@latest
 
       - name: Install Qt Official Build
         uses: jurplel/install-qt-action@v3
@@ -54,21 +42,43 @@ jobs:
           modules: ${{matrix.qt_modules}}
           cache: 'true'
 
+      - name: Install dependencies
+        run: |
+          pip install virtualenv
+      
       - name: Configure CMake
+        id: configure
         run: >
           cmake -B ${{ github.workspace }}/build
           -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
           -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          -DCMAKE_INSTALL_PREFIX=${{ matrix.install_path }}
+          -DGIT_BRANCH=${{ github.ref_name }}
           -S ${{ github.workspace }}
 
-      - name:  Build Project
-        run: cmake --build ${{ github.workspace }}/build --config ${{ matrix.build_type }} --parallel --target all_build --
+      - name: Build Project
+        run: cmake --build ${{github.workspace}}/build --config ${{ matrix.build_type }} --parallel
 
-      - name:  Install Project
+      - name: Install Project
         run: cmake --build ${{ github.workspace }}/build --config ${{ matrix.build_type }} --target install --
-
+      
       # when stable to test
       # - name: Test
       #   working-directory: ${{ github.workspace }}/build
       #   run: ctest --build-config ${{ matrix.build_type }}
+
+      - name: Archive build logs on failure
+        if: ${{ failure() && (steps.configure.outcome == 'failure' || steps.runvcpkg.outcome == 'failure') }}
+        run: |
+          tar -czvf ${{ github.workspace }}/build.tar.gz -C ${{ github.workspace }}/build/ .
+          tar -czvf ${{ github.workspace }}/vcpkg.tar.gz -C ${{ github.workspace }}/ThirdParty/vcpkg/buildtrees/ .
+
+      - name: Upload build logs artifact
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux_logs
+          path: |
+            ${{ github.workspace }}/build.tar.gz
+            ${{ github.workspace }}/vcpkg.tar.gz

--- a/vanillastyle/res/styles/LightVanillaStyle.json
+++ b/vanillastyle/res/styles/LightVanillaStyle.json
@@ -46,6 +46,7 @@
     "menuShortCutsBackground": "#CCDDE6ED",
     "comboBoxDropDownBackground": "#CCF5EFE6",
     "scrollBarSliderColor": "#939185"
+
   },
   "size": {
     "fontSize": 12,
@@ -73,6 +74,27 @@
   "progressBarMode": "mode2",
   "debug": true,
   "patch": [
+    {
+      "enable": true,
+      "widgetType": "QMenu",
+      "propertyValue": "CheckBoxWithNoBorder",
+      "configPatch": {
+        "color": {
+          "checkBoxBackground": "#00FFFFFF",
+          "checkBoxForeground": "#A4907C",
+          "checkBoxCheckedForeground": "#F5EEE6",
+          "checkBoxCheckedBackground": "#008D7B68",
+          "checkBoxHoveredBackground": "#00ffffff",
+          "checkBoxBorderColor": "#03AED2",
+          "menuBackground": "#99FFFFFF",
+          "menuSeparatorColor": "#CCF5EFE6",
+          "menuShortCutsBackground": "#CCDDE6ED"
+        },
+        "size": {
+          "checkBoxBorder": 0
+        }
+      }
+    },
     {
       "enable": true,
       "widgetType": "QMenu",

--- a/vanillastyle/src/Helper/Helper.cpp
+++ b/vanillastyle/src/Helper/Helper.cpp
@@ -149,6 +149,7 @@ void Helper::drawCheckBoxHelper(const QStyleOption* option, QPainter* painter, c
         renderRoundBorder(painter, buttonRect, borderColor, border, radius);
     }
 
+
     if ((theme->flags(option) & Theme::Checked) == Theme::Checked)
     {
         drawCheckBoxIndicator(option, rect, painter, theme);

--- a/vanillastyle/src/Helper/ItemViewStyle.cpp
+++ b/vanillastyle/src/Helper/ItemViewStyle.cpp
@@ -22,6 +22,7 @@ bool ItemViewStyle::draw(const QStyleOption* option, QPainter* painter, const st
     {
         drawCheck(opt, painter, theme, widget);
     }
+
     const auto rect = opt->rect;
     if (!opt->text.isEmpty())
     {
@@ -43,7 +44,6 @@ void ItemViewStyle::drawBackground(const QStyleOption* option, QPainter* painter
 {
     const auto* opt = qstyleoption_cast<const QStyleOptionViewItem*>(option);
     if (!opt)
-
     {
         return;
     }
@@ -91,55 +91,6 @@ void ItemViewStyle::drawBackground(const QStyleOption* option, QPainter* painter
                 bgColor = backgroundColor;
             }
         }
-    }
-
-    painter->setRenderHint(QPainter::Antialiasing);
-    const auto radius = theme->getSize(SizeRole::ItemViewRadius);
-    Helper::renderRoundRect(painter, rect.adjusted(1, 3, -1, -3), bgColor, radius);
-}
-
-void ItemViewStyle::drawCheck(const QStyleOptionViewItem* option, QPainter* painter, const std::shared_ptr<Theme>& theme, const QWidget* widget) const
-{
-    auto optChanged = *option;
-    optChanged.state = option->checkState == Qt::CheckState::Checked ? QStyle::State_On : QStyle::State_Off;
-    const auto padding = theme->getSize(SizeRole::NormalPadding);
-    const auto fgRect = option->rect.marginsRemoved(QMargins{padding, 0, padding, 0});
-    const auto iconSize = theme->getSize(SizeRole::IconSize);
-    optChanged.rect = QRect{fgRect.x(), fgRect.y() + (fgRect.height() - iconSize) / 2, iconSize, iconSize};
-    Helper::drawCheckBoxHelper(&optChanged, painter, theme, widget);
-}
-
-QSize ItemViewStyle::sizeFromContentsForItemView(QStyle::ContentsType type, const QStyleOption* option, const QSize& contentsSize,
-                                                 const std::shared_ptr<Theme>& theme, const QWidget* widget)
-{
-    if (type == QStyle::CT_ItemViewItem)
-    {
-        if (const auto* opt = qstyleoption_cast<const QStyleOptionViewItem*>(option))
-        {
-            const auto& features = opt->features;
-            const auto padding = theme->getSize(SizeRole::MenuItemPadding);
-
-            const auto hasIcon = features.testFlag(QStyleOptionViewItem::HasDecoration) && !opt->icon.isNull();
-            const auto& iconSize = hasIcon ? opt->decorationSize : QSize{0, 0};
-
-    {
-        return;
-    }
-
-    const auto& rect = QRectF(opt->rect);
-    const auto row = opt->index.row();
-    QColor bgColor;
-    if (row % 2 == 0)
-    {
-        bgColor = theme->getColor(opt, ColorRole::ItemViewEvenRowColor);
-    }
-    else
-    {
-        bgColor = theme->getColor(opt, ColorRole::ItemViewOddRowColor);
-    }
-    if (opt->state.testFlag(QStyle::State_Active) && opt->state.testFlag(QStyle::State_Selected))
-    {
-        bgColor = theme->getColor(option, ColorRole::ItemViewSelectedColor);
     }
 
     painter->setRenderHint(QPainter::Antialiasing);

--- a/vanillastyle/src/Style/VanillaStyle.cpp
+++ b/vanillastyle/src/Style/VanillaStyle.cpp
@@ -228,6 +228,7 @@ QSize VanillaStyle::sizeFromContents(ContentsType type, const QStyleOption* opti
         break;
     case CT_Splitter:
         helper = createHelper(d->helper, &Helper::sizeFromContentsForSplitterHandle);
+
     default:
         break;
     }

--- a/vanillastyle/src/Widgets/DotFloating.cpp
+++ b/vanillastyle/src/Widgets/DotFloating.cpp
@@ -100,8 +100,9 @@ void DotFloating::paintEvent(QPaintEvent* event)
     painter.fillRect(rect(), m_backgroundColor);
     painter.setPen(Qt::NoPen);
 
-    for (const auto& item : m_items | std::views::keys)
+    for (const auto& pair : m_items)
     {
+        const auto& item = pair.first;
         if (!item)
         {
             continue;
@@ -188,9 +189,13 @@ void DotFloating::initAnimations()
         seqAnimation->addAnimation(new QPauseAnimation((5 - index - 1) * 150, this));
     }
 
-    for (const auto& val : m_items | std::views::values)
+    for (const auto& pair : m_items)
     {
-        val->start();
+        const auto& val = pair.second;
+        if (val)
+        {
+            val->start();
+        }
     }
 }
 
@@ -200,8 +205,9 @@ QSize DotFloating::sizeHint() const
 }
 void DotFloating::stopAnimation()
 {
-    for (const auto& val : m_items | std::views::values)
+    for (const auto& pair : m_items)
     {
+        const auto& val = pair.second;
         if (val)
         {
             val->stop();
@@ -210,8 +216,9 @@ void DotFloating::stopAnimation()
 }
 void DotFloating::startAnimation()
 {
-    for (const auto& val : m_items | std::views::values)
+    for (const auto& pair : m_items)
     {
+        const auto& val = pair.second;
         if (val)
         {
             val->start();
@@ -223,8 +230,9 @@ void DotFloating::resetAnimation()
 {
     stopAnimation();
 
-    for (const auto& item : m_items | std::views::keys)
+    for (const auto& pair : m_items)
     {
+        const auto& item = pair.first;
         if (item)
         {
             item->setX(0.0f);


### PR DESCRIPTION
* chore(actions): update CI workflows

Upgrade GitHub Actions configurations with better practices and latest versions. Replaced `actions/checkout@v2` with `v4`, integrated vcpkg setup, simplified submodule handling, and added build log archiving on failure for Linux, Windows, and macOS workflows.

* chore(actions): update Ubuntu version in Linux CI workflow to 22.04

* chore(actions): remove vcpkg setup from CI workflows

* chore(actions): add Qt configurations to Linux CI workflow

* chore(actions): simplify Windows CI workflow by updating Qt installation and dependencies setup

* chore(actions): simplify Windows CI build command

Removed redundant `--target all` flag from the Windows CI `cmake` build command for improved clarity and consistency.

* fix(ItemViewStyle): fix rebase error

---------